### PR TITLE
Fixed the incorrect name metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 import setuptools
 
 setuptools.setup(
-    name='ethiopian_date',
+    name='ethiopian-date-converter',
     version=__import__('ethiopian_date').__version__,
     license='GNU General Public License (GPL), Version 3',
 


### PR DESCRIPTION
Turns out this is why the package wasn't installing correctly. The 'name' field in setup.py didn't match this line: `#egg=ethiopian-date-converter` in requirements.txt

(I also figured out how to get requirements.txt to point to a specific branch, so I tested it out and made sure this actually installs properly)